### PR TITLE
Extract geo bounding box

### DIFF
--- a/service.geo/lib/bounded_box.go
+++ b/service.geo/lib/bounded_box.go
@@ -1,0 +1,46 @@
+package lib
+
+import (
+	pb "github.com/harlow/go-micro-services/service.geo/proto"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+type Client struct {
+	conn   *grpc.ClientConn
+	client pb.GeoClient
+}
+
+func NewClient(addr string) (*Client, error) {
+	conn, err := grpc.Dial(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	client := pb.NewGeoClient(conn)
+
+	return &Client{
+		conn:   conn,
+		client: client,
+	}, nil
+}
+
+func (c Client) Close() error {
+	return c.conn.Close()
+}
+
+func (c Client) HotelsWithinBoundedBox(ctx context.Context, latitude int32, longitude int32) ([]int32, error) {
+	rect := &pb.Rectangle{
+		Lo: &pb.Point{Latitude: 400000000, Longitude: -750000000},
+		Hi: &pb.Point{Latitude: 420000000, Longitude: -730000000},
+	}
+
+	reply, err := c.client.BoundedBox(ctx, rect)
+
+	if err != nil {
+		return []int32{}, err
+	}
+
+	return reply.HotelIds, nil
+}

--- a/service.geo/main.go
+++ b/service.geo/main.go
@@ -15,6 +15,7 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 var (
@@ -33,14 +34,15 @@ type geoServer struct {
 }
 
 // BoundedBox returns all hotels contained within a given rectangle.
-func (s *geoServer) BoundedBox(ctx context.Context, args *pb.Args) (*pb.Reply, error) {
-	t := trace.Tracer{TraceID: args.TraceId}
-	t.In(serverName, args.From)
-	defer t.Out(args.From, serverName, time.Now())
+func (s *geoServer) BoundedBox(ctx context.Context, rect *pb.Rectangle) (*pb.Reply, error) {
+	md, _ := metadata.FromContext(ctx)
+	t := trace.Tracer{TraceID: md["traceID"]}
+	t.In(serverName, md["from"])
+	defer t.Out(md["from"], serverName, time.Now())
 
 	reply := new(pb.Reply)
 	for _, loc := range s.locations {
-		if inRange(loc.Point, args.Rect) {
+		if inRange(loc.Point, rect) {
 			reply.HotelIds = append(reply.HotelIds, loc.HotelID)
 		}
 	}

--- a/service.geo/proto/geo.pb.go
+++ b/service.geo/proto/geo.pb.go
@@ -9,7 +9,6 @@ It is generated from these files:
 	service.geo/proto/geo.proto
 
 It has these top-level messages:
-	Args
 	Rectangle
 	Point
 	Reply
@@ -32,23 +31,6 @@ var _ = proto.Marshal
 
 // A latitude-longitude bounding box, represented as two diagonally opposite
 // points "lo" and "hi".
-type Args struct {
-	TraceId string     `protobuf:"bytes,1,opt,name=traceId" json:"traceId,omitempty"`
-	From    string     `protobuf:"bytes,2,opt" json:"From,omitempty"`
-	Rect    *Rectangle `protobuf:"bytes,3,opt,name=rect" json:"rect,omitempty"`
-}
-
-func (m *Args) Reset()         { *m = Args{} }
-func (m *Args) String() string { return proto.CompactTextString(m) }
-func (*Args) ProtoMessage()    {}
-
-func (m *Args) GetRect() *Rectangle {
-	if m != nil {
-		return m.Rect
-	}
-	return nil
-}
-
 type Rectangle struct {
 	Lo *Point `protobuf:"bytes,2,opt,name=lo" json:"lo,omitempty"`
 	Hi *Point `protobuf:"bytes,3,opt,name=hi" json:"hi,omitempty"`
@@ -100,7 +82,7 @@ func init() {
 
 type GeoClient interface {
 	// Obtains the Locations contained within the given Rectangle.
-	BoundedBox(ctx context.Context, in *Args, opts ...grpc.CallOption) (*Reply, error)
+	BoundedBox(ctx context.Context, in *Rectangle, opts ...grpc.CallOption) (*Reply, error)
 }
 
 type geoClient struct {
@@ -111,7 +93,7 @@ func NewGeoClient(cc *grpc.ClientConn) GeoClient {
 	return &geoClient{cc}
 }
 
-func (c *geoClient) BoundedBox(ctx context.Context, in *Args, opts ...grpc.CallOption) (*Reply, error) {
+func (c *geoClient) BoundedBox(ctx context.Context, in *Rectangle, opts ...grpc.CallOption) (*Reply, error) {
 	out := new(Reply)
 	err := grpc.Invoke(ctx, "/geo.Geo/BoundedBox", in, out, c.cc, opts...)
 	if err != nil {
@@ -124,7 +106,7 @@ func (c *geoClient) BoundedBox(ctx context.Context, in *Args, opts ...grpc.CallO
 
 type GeoServer interface {
 	// Obtains the Locations contained within the given Rectangle.
-	BoundedBox(context.Context, *Args) (*Reply, error)
+	BoundedBox(context.Context, *Rectangle) (*Reply, error)
 }
 
 func RegisterGeoServer(s *grpc.Server, srv GeoServer) {
@@ -132,7 +114,7 @@ func RegisterGeoServer(s *grpc.Server, srv GeoServer) {
 }
 
 func _Geo_BoundedBox_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
-	in := new(Args)
+	in := new(Rectangle)
 	if err := proto.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}

--- a/service.geo/proto/geo.proto
+++ b/service.geo/proto/geo.proto
@@ -4,17 +4,11 @@ package geo;
 
 service Geo {
   // Obtains the Locations contained within the given Rectangle.
-  rpc BoundedBox(Args) returns (Reply);
+  rpc BoundedBox(Rectangle) returns (Reply);
 }
 
 // A latitude-longitude bounding box, represented as two diagonally opposite
 // points "lo" and "hi".
-message Args {
-  string traceId = 1;
-  string From = 2;
-  Rectangle rect = 3;
-}
-
 message Rectangle {
   Point lo = 2;
   Point hi = 3;


### PR DESCRIPTION
By adding a client to the geo service library we can abstract the
knowledge of gRPC and simply find locations within a bounding box.
- Use ctx instead of passing traceID and from vars around
- Simplify the Protobuf messages
