### PR TITLE
Add client-side load balancing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -68,6 +68,12 @@
   revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
 
 [[projects]]
+  name = "github.com/olivere/grpc"
+  packages = ["lb/consul"]
+  revision = "fec704fef18da7cd0da77c6840bed0b25b07d570"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/opentracing-contrib/go-stdlib"
   packages = ["nethttp"]
@@ -183,6 +189,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "33c619b093d1c07a405f98868d7cff0417377bc6bf87448a8243dbe6adc20abe"
+  inputs-digest = "d6e37e604116f8edd7366fc8611caf6f8bf54e30de7c5c3efe3a87c232ffa3b3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@ services:
     ports:
       - "5000:5000"
     links:
-      - search
-      - profile
       - jaeger
       - consul
     depends_on:
@@ -31,8 +29,6 @@ services:
     build: .
     entrypoint: search
     links:
-      - geo
-      - rate
       - jaeger
       - consul
     depends_on:

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -4,36 +4,29 @@ import (
 	"fmt"
 	"net"
 
-	consul "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api"
 )
 
-// Client provides an interface for communicating with registry
-type Client interface {
-	Register(string, int) error
-	Deregister(string) error
-	Service(string) ([]string, error)
-}
-
-// NewClient returns an implementation of the Client interface, wrapping a
-// concrete Consul client.
-func NewClient(addr string) (Client, error) {
-	cfg := consul.DefaultConfig()
+// NewClient returns a new Client with connection to consul
+func NewClient(addr string) (*Client, error) {
+	cfg := api.DefaultConfig()
 	cfg.Address = addr
 
-	c, err := consul.NewClient(cfg)
+	c, err := api.NewClient(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return &client{consul: c}, nil
+	return &Client{c}, nil
 }
 
-type client struct {
-	consul *consul.Client
+// Client provides an interface for communicating with registry
+type Client struct {
+	*api.Client
 }
 
 // Register a service with registry
-func (c *client) Register(name string, port int) error {
+func (c *Client) Register(name string, port int) error {
 	conn, err := net.Dial("udp", "8.8.8.8:80")
 	if err != nil {
 		return fmt.Errorf("unable to determine local addr: %v", err)
@@ -42,34 +35,17 @@ func (c *client) Register(name string, port int) error {
 
 	localAddr := conn.LocalAddr().(*net.UDPAddr)
 
-	reg := &consul.AgentServiceRegistration{
+	reg := &api.AgentServiceRegistration{
 		ID:      name,
 		Name:    name,
 		Port:    port,
 		Address: localAddr.IP.String(),
 	}
 
-	return c.consul.Agent().ServiceRegister(reg)
+	return c.Agent().ServiceRegister(reg)
 }
 
 // Deregister removes the service address from registry
-func (c *client) Deregister(id string) error {
-	return c.consul.Agent().ServiceDeregister(id)
-}
-
-// Service returns the addresses for a given service
-func (c *client) Service(name string) ([]string, error) {
-	resp, _, err := c.consul.Health().Service(name, "", false, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	ss := []string{}
-	for _, s := range resp {
-		ss = append(
-			ss,
-			fmt.Sprintf("%s:%d", s.Service.Address, s.Service.Port),
-		)
-	}
-	return ss, nil
+func (c *Client) Deregister(id string) error {
+	return c.Agent().ServiceDeregister(id)
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/hashicorp/consul/api"
+	consul "github.com/hashicorp/consul/api"
 )
 
 // NewClient returns a new Client with connection to consul
 func NewClient(addr string) (*Client, error) {
-	cfg := api.DefaultConfig()
+	cfg := consul.DefaultConfig()
 	cfg.Address = addr
 
-	c, err := api.NewClient(cfg)
+	c, err := consul.NewClient(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -22,7 +22,7 @@ func NewClient(addr string) (*Client, error) {
 
 // Client provides an interface for communicating with registry
 type Client struct {
-	*api.Client
+	*consul.Client
 }
 
 // Register a service with registry
@@ -35,7 +35,7 @@ func (c *Client) Register(name string, port int) error {
 
 	localAddr := conn.LocalAddr().(*net.UDPAddr)
 
-	reg := &api.AgentServiceRegistration{
+	reg := &consul.AgentServiceRegistration{
 		ID:      name,
 		Name:    name,
 		Port:    port,

--- a/services/geo/server.go
+++ b/services/geo/server.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	serviceName      = "srv-geo"
+	name             = "srv-geo"
 	maxSearchRadius  = 10
 	maxSearchResults = 5
 )
@@ -25,8 +25,9 @@ const (
 // Server implements the geo service
 type Server struct {
 	index *geoindex.ClusteringIndex
+	uuid  string
 
-	Registry registry.Client
+	Registry *registry.Client
 	Tracer   opentracing.Tracer
 	Port     int
 }
@@ -56,12 +57,17 @@ func (s *Server) Run() error {
 	}
 
 	// register the service
-	err = s.Registry.Register(serviceName, s.Port)
+	err = s.Registry.Register(name, s.Port)
 	if err != nil {
 		return fmt.Errorf("failed register: %v", err)
 	}
 
 	return srv.Serve(lis)
+}
+
+// Shutdown cleans up any processes
+func (s *Server) Shutdown() {
+	s.Registry.Deregister(name)
 }
 
 // Nearby returns all hotels within a given distance.

--- a/services/profile/server.go
+++ b/services/profile/server.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const serviceName = "srv-profile"
+const name = "srv-profile"
 
 // Server implements the profile service
 type Server struct {
@@ -23,7 +23,7 @@ type Server struct {
 
 	Tracer   opentracing.Tracer
 	Port     int
-	Registry registry.Client
+	Registry *registry.Client
 }
 
 // Run starts the server
@@ -50,12 +50,17 @@ func (s *Server) Run() error {
 	}
 
 	// register the service
-	err = s.Registry.Register(serviceName, s.Port)
+	err = s.Registry.Register(name, s.Port)
 	if err != nil {
 		return fmt.Errorf("failed register: %v", err)
 	}
 
 	return srv.Serve(lis)
+}
+
+// Shutdown cleans up any processes
+func (s *Server) Shutdown() {
+	s.Registry.Deregister(name)
 }
 
 // GetProfiles returns hotel profiles for requested IDs

--- a/services/rate/server.go
+++ b/services/rate/server.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const serviceName = "srv-rate"
+const name = "srv-rate"
 
 // Server implements the rate service
 type Server struct {
@@ -23,7 +23,7 @@ type Server struct {
 
 	Tracer   opentracing.Tracer
 	Port     int
-	Registry registry.Client
+	Registry *registry.Client
 }
 
 // Run starts the server
@@ -50,12 +50,17 @@ func (s *Server) Run() error {
 	}
 
 	// register the service
-	err = s.Registry.Register(serviceName, s.Port)
+	err = s.Registry.Register(name, s.Port)
 	if err != nil {
 		return fmt.Errorf("failed register: %v", err)
 	}
 
 	return srv.Serve(lis)
+}
+
+// Shutdown cleans up any processes
+func (s *Server) Shutdown() {
+	s.Registry.Deregister(name)
 }
 
 // GetRates gets rates for hotels for specific date range.

--- a/tracing/grpc.go
+++ b/tracing/grpc.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
-	"github.com/hashicorp/consul/api"
+	consul "github.com/hashicorp/consul/api"
 	lb "github.com/olivere/grpc/lb/consul"
 	opentracing "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 )
 
 // Dialer returns a load balanced grpc client conn with tracing interceptor
-func Dialer(name string, tracer opentracing.Tracer, registry *api.Client) (*grpc.ClientConn, error) {
+func Dialer(name string, tracer opentracing.Tracer, registry *consul.Client) (*grpc.ClientConn, error) {
 	r, err := lb.NewResolver(registry, name, "")
 	if err != nil {
 		return nil, err

--- a/tracing/grpc.go
+++ b/tracing/grpc.go
@@ -10,10 +10,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// Dialer returns a grpc client connection with tracing interceptor
+// Dialer returns a load balanced grpc client conn with tracing interceptor
 func Dialer(name string, tracer opentracing.Tracer, registry *api.Client) (*grpc.ClientConn, error) {
-	// tracer and registry options
-
 	r, err := lb.NewResolver(registry, name, "")
 	if err != nil {
 		return nil, err

--- a/tracing/grpc.go
+++ b/tracing/grpc.go
@@ -4,19 +4,29 @@ import (
 	"fmt"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/hashicorp/consul/api"
+	lb "github.com/olivere/grpc/lb/consul"
 	opentracing "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 )
 
 // Dialer returns a grpc client connection with tracing interceptor
-func Dialer(addr string, tracer opentracing.Tracer) (*grpc.ClientConn, error) {
+func Dialer(name string, tracer opentracing.Tracer, registry *api.Client) (*grpc.ClientConn, error) {
+	// tracer and registry options
+
+	r, err := lb.NewResolver(registry, name, "")
+	if err != nil {
+		return nil, err
+	}
+
 	conn, err := grpc.Dial(
-		addr,
+		name,
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(otgrpc.OpenTracingClientInterceptor(tracer)),
+		grpc.WithBalancer(grpc.RoundRobin(r)),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial %s: %v", addr, err)
+		return nil, fmt.Errorf("failed to dial %s: %v", name, err)
 	}
 	return conn, nil
 }

--- a/vendor/github.com/olivere/grpc/LICENSE
+++ b/vendor/github.com/olivere/grpc/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+Copyright © 2016-present Oliver Eilhard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.

--- a/vendor/github.com/olivere/grpc/lb/consul/consul.go
+++ b/vendor/github.com/olivere/grpc/lb/consul/consul.go
@@ -1,0 +1,161 @@
+// Copyright 2016-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package consul
+
+import (
+	"log"
+	"net"
+	"strconv"
+
+	"github.com/hashicorp/consul/api"
+	"google.golang.org/grpc/naming"
+)
+
+// Resolver implements the gRPC Resolver interface using a Consul backend.
+//
+// See the gRPC load balancing documentation for details about Balancer and
+// Resolver: https://github.com/grpc/grpc/blob/master/doc/load-balancing.md.
+type Resolver struct {
+	c           *api.Client
+	service     string
+	tag         string
+	passingOnly bool
+
+	quitc    chan struct{}
+	updatesc chan []*naming.Update
+}
+
+// NewResolver initializes and returns a new Resolver.
+//
+// It resolves addresses for gRPC connections to the given service and tag.
+// If the tag is irrelevant, use an empty string.
+func NewResolver(client *api.Client, service, tag string) (*Resolver, error) {
+	r := &Resolver{
+		c:           client,
+		service:     service,
+		tag:         tag,
+		passingOnly: true,
+		quitc:       make(chan struct{}),
+		updatesc:    make(chan []*naming.Update, 1),
+	}
+
+	// Retrieve instances immediately
+	instances, index, err := r.getInstances(0)
+	if err != nil {
+		log.Printf("grpc/lb/consul: error retrieving instances from Consul: %v", err)
+	}
+	updates := r.makeUpdates(nil, instances)
+	if len(updates) > 0 {
+		r.updatesc <- updates
+	}
+
+	// Start updater
+	go r.updater(instances, index)
+
+	return r, nil
+}
+
+// Resolve creates a watcher for target. The watcher interface is implemented
+// by Resolver as well, see Next and Close.
+func (r *Resolver) Resolve(target string) (naming.Watcher, error) {
+	return r, nil
+}
+
+// Next blocks until an update or error happens. It may return one or more
+// updates. The first call will return the full set of instances available
+// as NewResolver will look those up. Subsequent calls to Next() will
+// block until the resolver finds any new or removed instance.
+//
+// An error is returned if and only if the watcher cannot recover.
+func (r *Resolver) Next() ([]*naming.Update, error) {
+	return <-r.updatesc, nil
+}
+
+// Close closes the watcher.
+func (r *Resolver) Close() {
+	select {
+	case <-r.quitc:
+	default:
+		close(r.quitc)
+		close(r.updatesc)
+	}
+}
+
+// updater is a background process started in NewResolver. It takes
+// a list of previously resolved instances (in the format of host:port, e.g.
+// 192.168.0.1:1234) and the last index returned from Consul.
+func (r *Resolver) updater(instances []string, lastIndex uint64) {
+	var err error
+	var oldInstances = instances
+	var newInstances []string
+
+	// TODO Cache the updates for a while, so that we don't overwhelm Consul.
+	for {
+		select {
+		case <-r.quitc:
+			break
+		default:
+			newInstances, lastIndex, err = r.getInstances(lastIndex)
+			if err != nil {
+				log.Printf("grpc/lb/consul: error retrieving instances from Consul: %v", err)
+				continue
+			}
+			updates := r.makeUpdates(oldInstances, newInstances)
+			if len(updates) > 0 {
+				r.updatesc <- updates
+			}
+			oldInstances = newInstances
+		}
+	}
+}
+
+// getInstances retrieves the new set of instances registered for the
+// service from Consul.
+func (r *Resolver) getInstances(lastIndex uint64) ([]string, uint64, error) {
+	services, meta, err := r.c.Health().Service(r.service, r.tag, r.passingOnly, &api.QueryOptions{
+		WaitIndex: lastIndex,
+	})
+	if err != nil {
+		return nil, lastIndex, err
+	}
+
+	var instances []string
+	for _, service := range services {
+		s := service.Service.Address
+		if len(s) == 0 {
+			s = service.Node.Address
+		}
+		addr := net.JoinHostPort(s, strconv.Itoa(service.Service.Port))
+		instances = append(instances, addr)
+	}
+	return instances, meta.LastIndex, nil
+}
+
+// makeUpdates calculates the difference between and old and a new set of
+// instances and turns it into an array of naming.Updates.
+func (r *Resolver) makeUpdates(oldInstances, newInstances []string) []*naming.Update {
+	oldAddr := make(map[string]struct{}, len(oldInstances))
+	for _, instance := range oldInstances {
+		oldAddr[instance] = struct{}{}
+	}
+	newAddr := make(map[string]struct{}, len(newInstances))
+	for _, instance := range newInstances {
+		newAddr[instance] = struct{}{}
+	}
+
+	var updates []*naming.Update
+	for addr := range newAddr {
+		if _, ok := oldAddr[addr]; !ok {
+			updates = append(updates, &naming.Update{Op: naming.Add, Addr: addr})
+		}
+	}
+	for addr := range oldAddr {
+		if _, ok := newAddr[addr]; !ok {
+			updates = append(updates, &naming.Update{Op: naming.Delete, Addr: addr})
+		}
+	}
+
+	return updates
+}


### PR DESCRIPTION
This will allow the grpc dialer to accept a load balancing option when
creating the connection. The lb library takes a consul connection and
uses the addresses returned for a particular service name.

Addresses: #26