### PR TITLE
Move all the services under internal

### DIFF
--- a/cmd/go-micro-services/main.go
+++ b/cmd/go-micro-services/main.go
@@ -7,7 +7,11 @@ import (
 	"os"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
-	services "github.com/harlow/go-micro-services"
+	frontendsrv "github.com/harlow/go-micro-services/internal/services/frontend"
+	geosrv "github.com/harlow/go-micro-services/internal/services/geo"
+	profilesrv "github.com/harlow/go-micro-services/internal/services/profile"
+	ratesrv "github.com/harlow/go-micro-services/internal/services/rate"
+	searchsrv "github.com/harlow/go-micro-services/internal/services/search"
 	"github.com/harlow/go-micro-services/internal/trace"
 	opentracing "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
@@ -38,19 +42,19 @@ func main() {
 
 	switch cmd {
 	case "geo":
-		srv = services.NewGeo(t)
+		srv = geosrv.New(t)
 	case "rate":
-		srv = services.NewRate(t)
+		srv = ratesrv.New(t)
 	case "profile":
-		srv = services.NewProfile(t)
+		srv = profilesrv.New(t)
 	case "search":
-		srv = services.NewSearch(
+		srv = searchsrv.New(
 			t,
 			dial(*geoaddr, t),
 			dial(*rateaddr, t),
 		)
 	case "frontend":
-		srv = services.NewFrontend(
+		srv = frontendsrv.New(
 			t,
 			dial(*searchaddr, t),
 			dial(*profileaddr, t),

--- a/internal/services/frontend/frontend.go
+++ b/internal/services/frontend/frontend.go
@@ -1,19 +1,19 @@
-package services
+package geo
 
 import (
 	"encoding/json"
 	"fmt"
 	"net/http"
 
-	"github.com/harlow/go-micro-services/internal/trace"
 	"github.com/harlow/go-micro-services/internal/proto/profile"
 	"github.com/harlow/go-micro-services/internal/proto/search"
+	"github.com/harlow/go-micro-services/internal/trace"
 	opentracing "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 )
 
-// NewFrontend returns a new server
-func NewFrontend(t opentracing.Tracer, searchconn, profileconn *grpc.ClientConn) *Frontend {
+// New returns a new server
+func New(t opentracing.Tracer, searchconn, profileconn *grpc.ClientConn) *Frontend {
 	return &Frontend{
 		searchClient:  search.NewSearchClient(searchconn),
 		profileClient: profile.NewProfileClient(profileconn),

--- a/internal/services/geo/geo.go
+++ b/internal/services/geo/geo.go
@@ -32,8 +32,8 @@ func (p *point) Lat() float64 { return p.Plat }
 func (p *point) Lon() float64 { return p.Plon }
 func (p *point) Id() string   { return p.Pid }
 
-// NewGeo returns a new server
-func NewGeo(tr opentracing.Tracer) *Geo {
+// New returns a new server
+func New(tr opentracing.Tracer) *Geo {
 	return &Geo{
 		tracer: tr,
 		geoidx: newGeoIndex("data/geo.json"),

--- a/internal/services/profile/profile.go
+++ b/internal/services/profile/profile.go
@@ -1,4 +1,4 @@
-package services
+package profile
 
 import (
 	"encoding/json"
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// NewProfile returns a new server
-func NewProfile(tr opentracing.Tracer) *Profile {
+// New returns a new server
+func New(tr opentracing.Tracer) *Profile {
 	return &Profile{
 		tracer:   tr,
 		profiles: loadProfiles("data/hotels.json"),

--- a/internal/services/profile/profile_test.go
+++ b/internal/services/profile/profile_test.go
@@ -1,4 +1,4 @@
-package services
+package profile
 
 import (
 	"testing"
@@ -9,7 +9,7 @@ import (
 func TestGetProfile(t *testing.T) {
 	s := &Profile{
 		profiles: map[string]*profile.Hotel{
-			"1": &profile.Hotel{Id: "1", Name: "Cliff Hotel"},
+			"1": {Id: "1", Name: "Cliff Hotel"},
 		},
 	}
 

--- a/internal/services/rate/rate.go
+++ b/internal/services/rate/rate.go
@@ -1,4 +1,4 @@
-package services
+package rate
 
 import (
 	"encoding/json"
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// NewRate returns a new server
-func NewRate(tr opentracing.Tracer) *Rate {
+// New returns a new server
+func New(tr opentracing.Tracer) *Rate {
 	return &Rate{
 		tracer:    tr,
 		rateTable: loadRateTable("data/inventory.json"),

--- a/internal/services/search/search.go
+++ b/internal/services/search/search.go
@@ -1,4 +1,4 @@
-package services
+package search
 
 import (
 	"fmt"
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// NewSearch returns a new server
-func NewSearch(t opentracing.Tracer, geoconn, rateconn *grpc.ClientConn) *Search {
+// New returns a new server
+func New(t opentracing.Tracer, geoconn, rateconn *grpc.ClientConn) *Search {
 	return &Search{
 		geoClient:  geo.NewGeoClient(geoconn),
 		rateClient: rate.NewRateClient(rateconn),


### PR DESCRIPTION
This PR puts each of the services into their own package. This follows the internal pattern to reduce public API service

https://dave.cheney.net/2019/10/06/use-internal-packages-to-reduce-your-public-api-surface